### PR TITLE
refractor enrollment invite and pay page by extract header and footer…

### DIFF
--- a/app/assets/stylesheets/blocks/enrollment-site-header-layout.css.sass
+++ b/app/assets/stylesheets/blocks/enrollment-site-header-layout.css.sass
@@ -1,0 +1,13 @@
+#enrollment-layout-header
+  margin: 0 auto
+  max-width: 620px
+  padding: 1.11111em 0px
+  .site-header 
+    position: relative
+    padding: 0.555556em
+    color: #656565
+@media (max-width: 619px) 
+  #enrollment-layout-header
+    padding: 1.11111em 1.11111em
+    
+  

--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -1,4 +1,5 @@
 class EnrollmentsController < ApplicationController
+  layout "enrollment", except: [:show]
 
   def create
     if params[:email].blank?

--- a/app/views/enrollments/invite.html.slim
+++ b/app/views/enrollments/invite.html.slim
@@ -1,7 +1,4 @@
 .container
-  header.site-header
-    a.site-header__root href="/"
-    h1.site-header__title= @course.title
 
   .course-invite
     h1.emphasize 邀请函
@@ -52,10 +49,6 @@
       - partner = @course_invite.partnership_name
       - token = @course_invite.token
     = render partial: "personal_info_form", locals: {partner: partner, token: token}
-
-footer.site-footer
-  img.site-footer__logo src=image_url('logo2.png')
-
 
 javascript:
   if($('.js-bind-success').length == 0 ){

--- a/app/views/enrollments/pay.html.slim
+++ b/app/views/enrollments/pay.html.slim
@@ -1,9 +1,5 @@
 .container
   header.site-header.site-header--center
-    a.site-header__root href="/"
-    h1.site-header__title
-      | #{@course.name}
-
 
     .u-center-text
       h1.header.header--h1.header--underline 邀请函
@@ -44,9 +40,6 @@
             label.checkbox__label for='have-paid'
               span.checkbox__label__span
               | &nbsp;&nbsp;我已经通过支付宝付款了
-
-  footer.site-footer
-    img.site-footer__logo src=image_url('logo2.png')
 
 
 

--- a/app/views/layouts/enrollment.html.slim
+++ b/app/views/layouts/enrollment.html.slim
@@ -1,0 +1,23 @@
+doctype html
+head
+  title 思客教学
+  = stylesheet_link_tag    'application', media: 'all'
+  = stylesheet_link_tag    '/sike-fonts/styles.css'
+
+  = javascript_include_tag 'application'
+  = csrf_meta_tags
+  = favicon_link_tag "favicon.ico"
+  meta name="viewport" content="width=device-width, initial-scale=1"
+body id=page_identifier class="sike-global"
+  .flash-message-box.js-dismissable
+    - [:success, :error, :info].each do |type|
+      - if flash[type]
+        .flash-message class="flash-message--#{type}" = flash[type]
+  header#enrollment-layout-header.site-header
+    a.site-header__root href="/"
+    h1.site-header__title= @course.title
+
+  == yield
+  
+  footer.site-footer
+    img.site-footer__logo src=image_url('logo2.png')


### PR DESCRIPTION
重构enrollment​​模块中invite和pay的header与footer重构。将其分别使用enrolment.html.slim这个layout文件。以下是相关验证截图：
invite header pc效果
<img width="1249" alt="invite-header-pc" src="https://cloud.githubusercontent.com/assets/11813454/8688993/03f7a9ce-2ad5-11e5-8799-4b7ee583304f.png">
invite footer pc效果
<img width="1251" alt="invite-footer-pc" src="https://cloud.githubusercontent.com/assets/11813454/8688991/03d30c04-2ad5-11e5-8b9c-63b8ba1d096f.png">
invite header phone效果
<img width="351" alt="invite-header-phone" src="https://cloud.githubusercontent.com/assets/11813454/8688994/040d7862-2ad5-11e5-9c9d-3cfeccedf0d2.png">
invite footer phone效果
<img width="346" alt="invite-footer-phone" src="https://cloud.githubusercontent.com/assets/11813454/8688990/032e623a-2ad5-11e5-92e3-62cfb7ecd0e2.png">

pay header pc 效果
<img width="1279" alt="pay-header-pc" src="https://cloud.githubusercontent.com/assets/11813454/8688995/0420419a-2ad5-11e5-8f3d-840c1f4fe6eb.png">
pay footer pc 效果
<img width="1278" alt="pay-footer-pc" src="https://cloud.githubusercontent.com/assets/11813454/8688992/03e349de-2ad5-11e5-9b6d-a35733f6e972.png">
pay header phone 效果
<img width="381" alt="pay-header-phone" src="https://cloud.githubusercontent.com/assets/11813454/8688996/04447038-2ad5-11e5-9e3f-0470e8168adf.png">
pay footer phone 效果
<img width="371" alt="pay-footer-phone" src="https://cloud.githubusercontent.com/assets/11813454/8688997/0444dfb4-2ad5-11e5-9d10-0ea09149dae2.png">
